### PR TITLE
- Allow nullable DateTime objects

### DIFF
--- a/src/ALoRa.Library/LoRaMessage.cs
+++ b/src/ALoRa.Library/LoRaMessage.cs
@@ -18,7 +18,7 @@ namespace ALoRa.Library
 
         public class LoRaMetadata
         {
-            public DateTime time { get; set; }
+            public DateTime? time { get; set; }
             public decimal frequency { get; set; }
             public string modulation { get; set; }
             public string data_rate { get; set; }
@@ -31,7 +31,7 @@ namespace ALoRa.Library
         {
             public string gtw_id { get; set; }
             public Int64 timestamp { get; set; }
-            public DateTime time { get; set; }
+            public DateTime? time { get; set; }
             public int channel { get; set; }
             public int rssi { get; set; }
             public decimal snr { get; set; }


### PR DESCRIPTION
Sometimes a TTN gateway returns null for the time property. As a result the application goes in break mode.

Detailed explanation: https://github.com/ekwus/ALoRa/issues/3#issuecomment-416174829